### PR TITLE
Add Cursor Cloud setup notes (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is a single, zero-dependency static site: the entire product is `index.html` (marketing/landing page for **NightTrader**, a Bitcoin-native exchange). There is no package manager, no build system, no backend, no database, and no tests.
+
+### Running it
+
+- Serve the folder with any static HTTP server and open the root. Example: `python3 -m http.server 8000` from the repo root, then visit `http://localhost:8000/`.
+- Opening `index.html` directly via `file://` also renders fully, but serve over HTTP if you need `navigator.clipboard` (the "Copy" button) to use the secure-context clipboard API. It falls back to select-all otherwise.
+
+### Interactive functionality (for smoke testing)
+
+- Clicking any annotation token (`.tok`) updates the right-margin note (`#note-tag` / `#note-body`) via inline JS at the bottom of `index.html`.
+- The Bitmessage "Copy" button (`#bm-copy`) copies the address; in an insecure context it selects the address text instead.
+
+### Build / lint / test
+
+- There is nothing to build, lint, or test — no toolchain is defined. Any changes are to plain HTML/CSS/vanilla JS in `index.html`; verify visually in a browser.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for this repository.

This repo is a **zero-dependency static site** — the whole product is a single `index.html` (the NightTrader landing page). There is no package manager, build system, backend, database, or test suite. Environment setup is therefore effectively a no-op; the only thing needed to run it is a static file server.

## Changes

- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting how to serve/run the page and how to smoke-test its interactive JS (annotation tokens + Bitmessage "Copy" button).

## How it was verified

- Served the site with `python3 -m http.server 8000` and confirmed `HTTP 200` + correct `<title>`.
- Loaded `http://localhost:8000/` in Chrome; the landing page renders correctly.
- Exercised the core interactive functionality: clicking highlighted code tokens updates the right-margin note (e.g. "YOUR KEY", "THE NODE KEY", "FORCE-MAJEURE EXIT"), and the Bitmessage "Copy" button changes to "COPIED".

[nighttrader_interactive_demo.mp4](https://cursor.com/agents/bc-cdc79685-9c03-47fb-b1ca-34ad5c0be004/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnighttrader_interactive_demo.mp4)

[Margin note updates after clicking a code token](https://cursor.com/agents/bc-cdc79685-9c03-47fb-b1ca-34ad5c0be004/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoken_note_updated.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdc79685-9c03-47fb-b1ca-34ad5c0be004?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdc79685-9c03-47fb-b1ca-34ad5c0be004&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

