### PR TITLE
Add subtle Bitcoin watermark to the hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,16 @@ nav a{border-bottom:1px solid transparent;color:var(--grey)}
 nav a:hover{background:none;color:var(--ink);border-bottom-color:var(--orange)}
 
 /* ---------- hero ---------- */
-.hero{padding:78px 0 56px}
+.hero{padding:78px 0 56px;position:relative;overflow:hidden}
+.hero > *:not(.hero-mark){position:relative;z-index:1}
+.hero-mark{
+  position:absolute;z-index:0;pointer-events:none;user-select:none;
+  /* Large watermark, tucked to the upper-right so it sits behind the headline */
+  width:min(520px,72vw);height:auto;
+  top:-8%;right:-6%;
+  color:var(--orange);opacity:.09;
+}
+.hero-mark svg{display:block;width:100%;height:auto}
 .kicker{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:var(--orange);margin-bottom:26px}
 h1 .thin{color:var(--grey)}
 .hero .answer{
@@ -81,6 +90,9 @@ h1 .thin{color:var(--grey)}
 .btn:hover{background:var(--orange);border-color:var(--orange);color:var(--ink)}
 .btn.ghost{background:none;color:var(--ink)}
 .btn.ghost:hover{background:var(--ink);color:var(--paper);border-color:var(--ink)}
+@media (max-width:900px){
+  .hero-mark{width:min(360px,88vw);top:4%;right:-18%;opacity:.07}
+}
 
 /* ---------- signature: the annotated redeem script ---------- */
 .script{
@@ -252,6 +264,19 @@ footer li{margin-bottom:6px}
 <!-- ============ HERO ============ -->
 <section class="band">
   <div class="wrap hero">
+    <!-- Subtle Bitcoin watermark — inline SVG, no third-party request.
+         Mask punches the ₿ out of the disc so paper shows through even at low opacity. -->
+    <div class="hero-mark" aria-hidden="true">
+      <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" focusable="false">
+        <defs>
+          <mask id="btc-cut">
+            <circle cx="32" cy="32" r="32" fill="#fff"/>
+            <path fill="#000" d="M44.5 27.3c.6-4.1-2.5-6.3-6.8-7.8l1.4-5.6-3.4-.8-1.3 5.4c-.9-.2-1.8-.4-2.7-.6l1.4-5.4-3.4-.8-1.4 5.6c-.7-.2-1.4-.3-2.1-.5l.01-.04-4.7-1.2-.9 3.6s2.5.6 2.5.6c1.4.3 1.6 1.2 1.6 1.9l-1.6 6.4c.1 0 .2.1.3.1h-.3l-2.2 8.9c-.2.4-.6 1.1-1.6.8 0 0-2.5-.6-2.5-.6l-1.7 3.9 4.4 1.1c.8.2 1.6.4 2.4.6l-1.4 5.6 3.4.8 1.4-5.6c.9.2 1.8.5 2.7.7l-1.4 5.5 3.4.8 1.4-5.6c5.8 1.1 10.2.7 12-4.6 1.5-4.2-.1-6.7-3.1-8.3 2.2-.5 3.9-2 4.3-5.1zm-7.7 10.8c-1.1 4.2-8.1 1.9-10.4 1.4l1.9-7.4c2.3.6 9.6 1.7 8.5 6zm1.1-10.9c-1 3.9-6.9 1.9-8.8 1.4l1.7-6.7c1.9.5 8.1 1.4 7.1 5.3z"/>
+          </mask>
+        </defs>
+        <circle cx="32" cy="32" r="32" fill="currentColor" mask="url(#btc-cut)"/>
+      </svg>
+    </div>
     <p class="kicker">Bitcoin-native · Non-custodial · Full bid / ask order book</p>
     <h1>Not your keys,<br>not your coins.<br><span class="thin">So we gave you a key.</span></h1>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a subtle Bitcoin logo as a background watermark in the hero section of the NightTrader landing page.

## Approach

- Inline SVG of the classic Bitcoin mark (no CDN / third-party request — matches the page’s “no third-party requests” rule).
- An SVG mask punches the ₿ out of the disc so paper shows through even at low opacity.
- Positioned upper-right behind the headline at ~9% opacity (slightly lower on small screens); `pointer-events: none` so it never blocks interaction.
- Hero children stay above it via `z-index`.

[Hero with subtle Bitcoin watermark](https://cursor.com/agents/bc-cdc79685-9c03-47fb-b1ca-34ad5c0be004/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhero_bitcoin_watermark.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdc79685-9c03-47fb-b1ca-34ad5c0be004?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdc79685-9c03-47fb-b1ca-34ad5c0be004&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

