### PR TITLE
Terms of use cleanup, mobile-friendly CTA overhaul, and history section

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,7 +563,6 @@ OP_ENDIF</pre>
         <div>
           <h4>Legal</h4>
           <ul>
-            <li><a href="/terms.html">Terms of use</a></li>
             <li><a href="#limits">Risk disclosure</a></li>
           </ul>
         </div>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#F7931A">
 <title>NightTrader — a Bitcoin order book you co-sign</title>
 <meta name="description" content="A Bitcoin-native exchange with a full bid/ask order book. Coins settle into multisig addresses you hold a key to, with a timelock that returns them if the nodes disappear.">
 <style>
@@ -44,7 +45,7 @@ a:hover{background:var(--orange);border-bottom-color:var(--orange)}
   color:var(--grey);padding-top:9px;
 }
 .gut b{display:block;color:var(--ink);font-weight:600}
-.col{max-width:720px}
+.col{max-width:720px;min-width:0}
 
 h1,h2,h3{font-family:var(--serif);font-weight:400;letter-spacing:-.015em;margin:0}
 h1{font-size:clamp(40px,7.2vw,74px);line-height:.98}
@@ -56,14 +57,15 @@ p.lede{font-size:19px;color:#2C2F34;max-width:62ch}
 .mono{font-family:var(--mono)}
 
 /* ---------- masthead ---------- */
-header{border-bottom:1px solid var(--rule);background:var(--paper)}
-.mast{display:flex;align-items:baseline;justify-content:space-between;gap:24px;padding:18px 0;flex-wrap:wrap}
+header{border-bottom:1px solid var(--rule);background:var(--paper);position:sticky;top:0;z-index:50}
+.mast{display:flex;align-items:center;justify-content:space-between;gap:24px;padding:16px 0;flex-wrap:wrap}
 .brand{font-family:var(--mono);font-size:13px;letter-spacing:.24em;font-weight:600;text-transform:uppercase;border:0}
 .brand:hover{background:none}
 .brand .dot{color:var(--orange)}
-nav{font-family:var(--mono);font-size:12px;letter-spacing:.08em;text-transform:uppercase;display:flex;gap:20px;flex-wrap:wrap}
-nav a{border-bottom:1px solid transparent;color:var(--grey)}
-nav a:hover{background:none;color:var(--ink);border-bottom-color:var(--orange)}
+nav{font-family:var(--mono);font-size:12px;letter-spacing:.08em;text-transform:uppercase;display:flex;align-items:center;gap:20px;flex-wrap:wrap}
+nav a:not(.btn){border-bottom:1px solid transparent;color:var(--grey);padding:8px 0}
+nav a:not(.btn):hover{background:none;color:var(--ink);border-bottom-color:var(--orange)}
+nav .btn.sm{margin-left:4px}
 
 /* ---------- hero ---------- */
 .hero{padding:78px 0 56px;position:relative;overflow:hidden}
@@ -83,15 +85,24 @@ h1 .thin{color:var(--grey)}
   margin:26px 0 30px;padding-left:16px;border-left:2px solid var(--orange);
 }
 .cta{display:flex;gap:12px;flex-wrap:wrap;margin-top:30px;align-items:center}
+.cta-note{font-family:var(--mono);font-size:12px;letter-spacing:.05em;color:var(--grey);margin:14px 0 0}
+.cta-note::before{content:"● ";color:var(--orange)}
 .btn{
-  font-family:var(--mono);font-size:13px;letter-spacing:.08em;text-transform:uppercase;
-  padding:13px 22px;border:1px solid var(--ink);background:var(--ink);color:var(--paper);
+  display:inline-flex;align-items:center;justify-content:center;text-align:center;
+  font-family:var(--mono);font-size:13px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;
+  padding:15px 26px;min-height:48px;border:1px solid var(--orange);background:var(--orange);color:var(--ink);
+  touch-action:manipulation;
 }
-.btn:hover{background:var(--orange);border-color:var(--orange);color:var(--ink)}
-.btn.ghost{background:none;color:var(--ink)}
+.btn:hover{background:var(--ink);border-color:var(--ink);color:var(--paper)}
+.btn.ghost{background:none;color:var(--ink);border-color:var(--ink)}
 .btn.ghost:hover{background:var(--ink);color:var(--paper);border-color:var(--ink)}
+.btn.sm{padding:9px 16px;min-height:36px;font-size:11px}
 @media (max-width:900px){
   .hero-mark{width:min(360px,88vw);top:4%;right:-18%;opacity:.07}
+}
+@media (max-width:560px){
+  .cta{flex-direction:column;align-items:stretch}
+  .cta .btn{width:100%}
 }
 
 /* ---------- signature: the annotated redeem script ---------- */
@@ -103,7 +114,8 @@ h1 .thin{color:var(--grey)}
   padding:12px 18px;border-bottom:1px solid var(--rule);
   font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--grey);
 }
-.script-body{display:grid;grid-template-columns:1fr 300px}
+.script-body{display:grid;grid-template-columns:1fr 300px;min-width:0}
+.script-body > *{min-width:0}
 pre.code{
   margin:0;padding:26px 20px;font-family:var(--mono);font-size:14px;line-height:2.05;
   overflow-x:auto;white-space:pre;
@@ -194,7 +206,7 @@ ul.ctrl p{margin:0;color:#33363B;font-size:15.5px}
 .node p{margin:0 0 16px;font-size:15px}
 .bm{display:flex;align-items:stretch;gap:0;flex-wrap:wrap;border:1px solid #24304A;background:#080D18}
 .bm code{
-  font-family:var(--mono);font-size:13px;color:#fff;padding:12px 14px;flex:1 1 300px;
+  font-family:var(--mono);font-size:13px;color:#fff;padding:12px 14px;flex:1 1 300px;min-width:0;
   overflow-x:auto;white-space:nowrap;letter-spacing:.01em;
 }
 .copy{
@@ -218,6 +230,7 @@ dl.trade dd{margin:8px 0 0;color:#33363B;font-size:15.5px}
 /* ---------- footer ---------- */
 footer{padding:52px 0 64px;font-size:13.5px;color:var(--grey)}
 .fgrid{display:grid;grid-template-columns:var(--gutter) 1fr;gap:0 40px}
+.fgrid > *{min-width:0}
 .fcols{display:grid;grid-template-columns:repeat(3,1fr);gap:28px;max-width:720px}
 footer h4{font-family:var(--mono);font-size:11px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink);margin:0 0 10px;font-weight:600}
 footer ul{list-style:none;margin:0;padding:0}
@@ -235,6 +248,19 @@ footer li{margin-bottom:6px}
   .fees{grid-template-columns:1fr}
   .fcols{grid-template-columns:1fr 1fr}
   .verify li{grid-template-columns:1fr;gap:4px}
+}
+@media (max-width:640px){
+  nav a:not(.btn){display:none}
+  nav{gap:0}
+  .hero{padding:48px 0 40px}
+  .tbl th,.tbl td{padding:12px 10px 12px 0;font-size:13.5px}
+}
+@media (max-width:480px){
+  :root{--pad:18px}
+  .fcols{grid-template-columns:1fr;gap:22px}
+  .bm{flex-direction:column}
+  .bm code{width:100%;flex:0 1 auto}
+  .copy{border-left:0;border-top:1px solid #24304A;justify-content:center;display:flex}
 }
 @media (prefers-reduced-motion:no-preference){
   .tok{transition:background .12s linear}
@@ -255,6 +281,7 @@ footer li{margin-bottom:6px}
       <a href="#fees">Fees</a>
       <a href="#privacy">Privacy</a>
       <a href="#limits">Tradeoffs</a>
+      <a class="btn sm" href="https://nighttrader.exchange">Open exchange</a>
     </nav>
   </div>
 </header>
@@ -290,6 +317,7 @@ footer li{margin-bottom:6px}
       <a class="btn ghost" href="https://github.com/NightTrader/nighttrader.github.io/blob/master/Nighttrader_A_Decentralized_Multisignature_Electronic_Cash_Wallet.pdf">Read the paper</a>
       <a class="btn ghost" href="#verify">Read the source</a>
     </div>
+    <p class="cta-note">Non-custodial · No signup wall to browse the book · Withdraw whenever you want</p>
 
     <!-- ===== SIGNATURE ELEMENT: the annotated redeem script ===== -->
     <div class="script">

--- a/index.html
+++ b/index.html
@@ -281,6 +281,7 @@ footer li{margin-bottom:6px}
       <a href="#fees">Fees</a>
       <a href="#privacy">Privacy</a>
       <a href="#limits">Tradeoffs</a>
+      <a href="#history">History</a>
       <a class="btn sm" href="https://nighttrader.exchange">Open exchange</a>
     </nav>
   </div>
@@ -559,6 +560,29 @@ OP_ENDIF</pre>
         <a class="btn" href="https://nighttrader.exchange">Open the exchange</a>
         <a class="btn ghost" href="#top">Back to the script</a>
       </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ HISTORY ============ -->
+<section class="band" id="history">
+  <div class="wrap row">
+    <div class="gut"><b>History</b>Since 2014</div>
+    <div class="col">
+      <h2>It started with an ATM on a street corner in Tijuana.</h2>
+      <p class="lede">bitcoin42 didn't begin as an exchange. It began as a bitcoin ATM operator — putting Genesis1 machines on the ground in Tijuana, Mexico in 2014, among the first of their kind anywhere.</p>
+      <p>Running machines was never the point. The order book was the plan from day one: a real exchange that never took custody of your coins, at a time when every exchange did exactly that. It took a decade — and watching custodian after custodian fail in the meantime — to build it right.</p>
+
+      <div class="tl">
+        <div class="tl-bar">
+          <span style="left:0"></span><span style="left:calc(100% - 2px)"></span>
+        </div>
+        <div class="tl-labels">
+          <span>2014 · Bitcoin ATMs, Tijuana</span><span><em>2024 · NightTrader launches</em></span>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top:22px">Coverage from the time: <a href="https://www.coindesk.com/markets/2014/03/28/money-spinners-genesis1-bitcoin-and-dogecoin-atms-arrive-in-tijuana-mexico">CoinDesk, March 2014</a> — Genesis1 bitcoin and dogecoin ATMs arrive in Tijuana.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Remove the "Terms of use" footer link (no `terms.html` exists to link to)
- Make the site more mobile-friendly and strengthen the CTA:
  - Sticky header with an always-visible "Open exchange" button; nav text links collapse on small screens
  - Primary buttons are solid orange by default (not just on `:hover`, which never fires on touch) with larger tap targets and a trust microcopy line under the hero CTA
  - Fixed real horizontal-scroll bugs on mobile — the comparison table, redeem-script code block, and Bitmessage address row were blowing out page width via classic CSS grid/flex "auto min-width" sizing; verified zero overflow from 320px up
  - Added `theme-color` meta and small-screen breakpoints (footer columns, table padding, full-width stacked CTA buttons)
- Add a short "History" section: bitcoin42 started in 2014 operating Genesis1 bitcoin/dogecoin ATMs in Tijuana (cited via CoinDesk's coverage at the time), with a decentralized exchange as the goal from day one — ten years later, that became NightTrader. Reuses the existing timelock timeline component for a simple 2014 → 2024 marker.

## Test plan
- [x] Verified with a headless browser at 320/375/414/480/640/768/900/1024/1440px widths — no horizontal overflow at any width
- [x] Visual review of hero, header, comparison table, Bitmessage block, footer, and new History section on both mobile and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RZTDWvoGJnp9cfTFCLLPU

---
_Generated by [Claude Code](https://claude.ai/code/session_012RZTDWvoGJnp9cfTFCLLPU)_